### PR TITLE
Don't use 'audioonly' for livestreams

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,12 +9,12 @@ function filter(format) {
 
 module.exports = function download(url, options = {}) {
 	return new Promise((resolve, reject) => {
-		Object.assign(options, { filter: 'audioonly' });
 		ytdl.getInfo(url, (err, info) => {
 			if (err) return reject(err);
 			// Prefer opus
 			const canDemux = info.formats.find(filter) && info.length_seconds != 0;
 			if (canDemux) Object.assign(options, { filter });
+			else if (info.length_seconds != 0) Object.assign(options, { filter: 'audioonly' });
 			const ytdlStream = ytdl.downloadFromInfo(info, options);
 			if (canDemux) {
 				const demuxer = new prism.opus.WebmDemuxer();


### PR DESCRIPTION
When using the `audioonly` filter with ytdl-core to download a livestream, the audio only plays for a couple of seconds after which it stops. This PR makes sure the `audioonly` filter is not used for livestreams.

More info: https://github.com/fent/node-ytdl-core/issues/231