### PR TITLE
expose all node-ytdl-core functions. (#36)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function filter(format) {
 		format.audio_sample_rate == 48000;
 }
 
-module.exports = function download(url, options = {}) {
+const ytdlDiscord = (url, options = {}) => {
 	return new Promise((resolve, reject) => {
 		ytdl.getInfo(url, (err, info) => {
 			if (err) return reject(err);
@@ -44,3 +44,15 @@ module.exports = function download(url, options = {}) {
 		});
 	});
 };
+
+ytdlDiscord.getBasicInfo = ytdl.getBasicInfo;
+ytdlDiscord.getInfo = ytdl.getFullInfo;
+ytdlDiscord.downloadFromInfo = ytdl.downloadFromInfo;
+ytdlDiscord.chooseFormat = ytdl.chooseFormat;
+ytdlDiscord.filterFormats = ytdl.filterFormats;
+ytdlDiscord.validateID = ytdl.validateID;
+ytdlDiscord.validateURL = ytdl.validateURL;
+ytdlDiscord.getURLVideoID = ytdl.getURLVideoID;
+ytdlDiscord.getVideoID = ytdl.getVideoID;
+
+module.exports = ytdlDiscord;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,7 +1,18 @@
 /// <reference types="node" />
 import { Readable } from 'stream';
-import { downloadOptions, videoFormat } from 'ytdl-core';
+import { downloadOptions, videoFormat, videoInfo, relatedVideo } from 'ytdl-core';
 export interface PrismVideoFormat extends videoFormat {
 	audio_sample_rate?: number;
 }
-export declare function download(url: string, options?: downloadOptions): Promise<Readable>;
+export declare function ytdlDiscord(url: string, options?: downloadOptions): Promise<Readable>
+export declare function getBasicInfo(url: string, callback?: (err: Error, info: videoInfo) => void): Promise<videoInfo>;
+export declare function getBasicInfo(url: string, options?: downloadOptions, callback?: (err: Error, info: videoInfo) => void): Promise<videoInfo>;
+export declare function getInfo(url: string, callback?: (err: Error, info: videoInfo) => void): Promise<videoInfo>;
+export declare function getInfo(url: string, options?: downloadOptions, callback?: (err: Error, info: videoInfo) => void): Promise<videoInfo>;
+export declare function downloadFromInfo(info: videoInfo, options?: downloadOptions): Readable;
+export declare function chooseFormat(format: videoFormat | videoFormat[], options?: downloadOptions): videoFormat | Error;
+export declare function filterFormats(formats: videoFormat | videoFormat[], filter?: 'video' | 'videoonly' | 'audio' | 'audioonly' | ((format: videoFormat) => boolean)): videoFormat[];
+export declare function validateID(string: string): boolean;
+export declare function validateURL(string: string): boolean;
+export declare function getURLVideoID(string: string): string | Error;
+export declare function getVideoID(string: string): string | Error;


### PR DESCRIPTION
To solve the problem described in #36.
Added API functions to `ytdl-core-discord` module:
- getBasicInfo
- getInfo
- downloadFromInfo
- chooseFormat
- filterFormats
- validateID
- validateURL
- getURLVideoID
- getVideoID

All added functions are a direct passthroug from `node-ytdl-core` with no added functionallity.
This PR changes the interface of the module but introduces no breaking changes.