### PR TITLE
chore: update ytdl-core dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1135,11 +1135,11 @@
       }
     },
     "ytdl-core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-2.0.1.tgz",
-      "integrity": "sha512-PZBcVzQpkBxi9OQh9I4QIrYNmkbM/zh4QJQuxE8I6RojLUVYkkps5iLYquE3H+pwmBXtEXQMDJfVRajgdiz+iA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-2.1.2.tgz",
+      "integrity": "sha512-/tOT9Pka6nX+LuvzNLBU8AbVHe8XELn3aZ69mvCxzvwO/ty9k8cRvF6jXqti7l5M+0hf+UPpP9jYPSAFAuoBUA==",
       "requires": {
-        "html-entities": "^1.1.3",
+        "html-entities": "^1.3.1",
         "m3u8stream": "^0.6.3",
         "miniget": "^1.7.0",
         "sax": "^1.1.3"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@types/node": "^13.11.1",
     "prism-media": "^1.2.1",
-    "ytdl-core": "^2.0.1"
+    "ytdl-core": "^2.1.2"
   },
   "devDependencies": {
     "eslint": "^6.8.0"


### PR DESCRIPTION
Fix issue when not finding format url from formats containing signatureCipher.
This should fix #174 .