### PR TITLE
Fix error on non-opus fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,12 +32,14 @@ function download(url, options = {}) {
 				const demuxer = new prism.opus.WebmDemuxer();
 				return resolve(ytdl.downloadFromInfo(info, options).pipe(demuxer).on('end', () => demuxer.destroy()));
 			} else {
+				const bestFormat = nextBestFormat(info.formats);
+				if (!bestFormat) return reject('No suitable format found');
 				const transcoder = new prism.FFmpeg({
 					args: [
 						'-reconnect', '1',
 						'-reconnect_streamed', '1',
 						'-reconnect_delay_max', '5',
-						'-i', nextBestFormat(info.formats).url,
+						'-i', bestFormat.url,
 						'-analyzeduration', '0',
 						'-loglevel', '0',
 						'-f', 's16le',


### PR DESCRIPTION
Due to weird shenanigans of YouTube, `nextBestFormat(info.formats)` could sometimes return `undefined` and provoke an error in index.js as seen here :

```
(node:522123) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'url' of undefined
    at ytdl.getInfo (/home/barkbork/discord-jukebox/node_modules/ytdl-core-discord/index.js:40:41)
    at exports.(anonymous function).then.info (/home/barkbork/discord-jukebox/node_modules/ytdl-core/lib/info.js:288:23)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

This commit aims to fix the issue by rejecting the Promise instead of letting it throw a hard-to-catch error.
 
Fixes #195 