### PR TITLE
bump ytdl-core to version 4.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@types/node": "^15.12.2",
         "prism-media": "^1.3.1",
-        "ytdl-core": "^4.8.2"
+        "ytdl-core": "^4.8.3"
       },
       "devDependencies": {
         "eslint": "^7.22.0"
@@ -1248,9 +1248,9 @@
       "dev": true
     },
     "node_modules/ytdl-core": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.8.2.tgz",
-      "integrity": "sha512-O3n++YcgZawaXJwbPmnRDgfN6b4kU0DpNdkI9Na5yM3JAdfJmoq5UHc8v9Xjgjr1RilQUUh7mhDnRRPDtKr0Kg==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.8.3.tgz",
+      "integrity": "sha512-cWCBeX4FCgjcKmuVK384MT582RIAakpUSeMF/NPVmhO8cWiG+LeQLnBordvLolb0iXYzfUvalgmycYAE5Sy6Xw==",
       "dependencies": {
         "m3u8stream": "^0.8.3",
         "miniget": "^4.0.0",
@@ -2245,9 +2245,9 @@
       "dev": true
     },
     "ytdl-core": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.8.2.tgz",
-      "integrity": "sha512-O3n++YcgZawaXJwbPmnRDgfN6b4kU0DpNdkI9Na5yM3JAdfJmoq5UHc8v9Xjgjr1RilQUUh7mhDnRRPDtKr0Kg==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-4.8.3.tgz",
+      "integrity": "sha512-cWCBeX4FCgjcKmuVK384MT582RIAakpUSeMF/NPVmhO8cWiG+LeQLnBordvLolb0iXYzfUvalgmycYAE5Sy6Xw==",
       "requires": {
         "m3u8stream": "^0.8.3",
         "miniget": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@types/node": "^15.12.2",
     "prism-media": "^1.3.1",
-    "ytdl-core": "^4.8.2"
+    "ytdl-core": "^4.8.3"
   },
   "devDependencies": {
     "eslint": "^7.22.0"


### PR DESCRIPTION
ytdl-core has a new release that solves the 404 errors that have been occurring. This PR just bumps the ytdl-core version to this new release.
https://github.com/fent/node-ytdl-core/releases/tag/v4.8.3